### PR TITLE
Support auto-pushing by Duo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ You can use this image to access Shibboleth-protected accounts.
 To create a temporary session, just run `shib-auth` inside the container:
 
 ```bash
- docker run --rm -it --volume "$HOME/.aws:/root/.aws" bostonuniversity/aws-tools shib-auth
+docker run --rm -it --volume "$HOME/.aws:/root/.aws" bostonuniversity/aws-tools shib-auth
 ```
 
-It is suggested to wrap the command above as an alias.
+It is suggested to wrap the command above as an alias:
+
+```bash
+echo "alias awslogin='docker run --rm -it --volume \"$HOME/.aws:/root/.aws\" bostonuniversity/aws-tools shib-auth'" >> ~/.bashrc
+# Source the file or re-login to your host
+```
 
 This session will only be available for a few hours but you can alway run that
 command again to create a new one.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can use this image to access Shibboleth-protected accounts.
 To create a temporary session, just run `shib-auth` inside the container:
 
 ```bash
-docker run --rm -it --volume "$HOME/.aws:/root/.aws" shib-auth
+ docker run --rm -it --volume "$HOME/.aws:/root/.aws" bostonuniversity/aws-tools shib-auth
 ```
 
 It is suggested to wrap the command above as an alias.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,40 @@
 
 A docker image for running AWS CLI commands.
 
-## Usage
+It could be used in two ways:
+
+1. You prefer to use your own version of AWS CLI but need to perform
+  Shibboleth authentication to your account
+
+1. You want to enjoy all available [AWS-related tools](#includes) by opening
+  a bash session inside the container
+
+## Usage: CLI for accounts with Shibboleth authentication
+
+You can use this image to access Shibboleth-protected accounts.
+To create a temporary session, just run `shib-auth` inside the container:
+
+```bash
+docker run --rm -it --volume "$HOME/.aws:/root/.aws" shib-auth
+```
+
+It is suggested to wrap the command above as an alias.
+
+This session will only be available for a few hours but you can alway run that
+command again to create a new one.
+
+Note that this container will attempt to use Duo 2FA authentication but it's
+been only tested for the `push` method (both manual and automated).
+
+You can modify these environment variables to fine-tune for your own case:
+
+Variable name        | Default value
+---------------------|------------------------------
+AWS_REGION           | `us-east-1`
+AWS_OUTPUT_FORMAT    | `json`
+AWS_LOGIN_URL        | `https://www.bu.edu/awslogin`
+
+## Usage: Bash Session
 
 ### Bash
 
@@ -52,21 +85,6 @@ bostonuniversity/aws-tools /bin/bash
 ```powershell
 docker run --rm -it --volume ${PWD}:/code --volume C:\Some\Temporary\Directory:/root/.aws --volume aws-tools:/root bostonuniversity/aws-tools /bin/bash
 ```
-
-## CLI for accounts with federated access
-
-You can use this image too access shibboleth-protected accounts (with Duo 2FA too).
-To create a temporary session, just run `shib-auth` inside the container.
-This session will only be available for a few hours but you can alway run that
-command again to create a new one.
-
-You can modify these environment variables to fine-tune for your own case:
-
-Variable name        | Default value
----------------------|------------------------------
-AWS_REGION           | `us-east-1`
-AWS_OUTPUT_FORMAT    | `json`
-AWS_LOGIN_URL        | `https://www.bu.edu/awslogin`
 
 ## Includes
 

--- a/aws-auth/auth.py
+++ b/aws-auth/auth.py
@@ -80,11 +80,11 @@ async def duo_wait(page, last_message=''):
     except TimeoutError:
         await duo_wait(page, last_message)
 
-async def is_saml_available(page):
-    return True if await page.querySelector('input[name=SAMLResponse]') else False
-
 async def is_duo_available(page):
     return True if await page.querySelector('#duo_iframe') else False
+
+async def is_saml_available(page):
+    return True if await page.querySelector('input[name=SAMLResponse]') else False
 
 async def main():
     # region: The default AWS region that this script will connect
@@ -135,17 +135,12 @@ async def main():
                 # When Duo is configured to automatically send push,
                 # saml may be already available at this step or will
                 # soon become available
-                if not await is_saml_available(page):
-                    if await is_duo_available(page):
-                        duo = await get_duo(page)
-                        message = await get_duo_message(duo)
-                        if message:
-                            print(message)
-                    else:
-                        raise ex
+                if not await is_saml_available(page) and not await is_duo_available(page):
+                    raise ex
 
         if await is_duo_available(page):
             await duo_auth(page)
+
     except Exception as ex:
         print('Unidentified error, check screenshot. Error message: ' + str(ex))
         await page.screenshot({'path': 'error.png'})

--- a/aws-auth/auth.py
+++ b/aws-auth/auth.py
@@ -29,7 +29,6 @@ async def basic_auth(page):
     await page.focus('[name*=pass]')
     await page.keyboard.type(password)
     await page.evaluate("document.querySelector('button[type=submit]').click()")
-    await page.waitForNavigation({ 'waitUntil': 'networkidle0', 'timeout': 15000 })
 
 async def get_duo_message(duo):
     message = await duo.querySelector('#messages-view')
@@ -81,6 +80,12 @@ async def duo_wait(page, last_message=''):
     except TimeoutError:
         await duo_wait(page, last_message)
 
+async def is_saml_available(page):
+    return True if await page.querySelector('input[name=SAMLResponse]') else False
+
+async def is_duo_available(page):
+    return True if await page.querySelector('#duo_iframe') else False
+
 async def main():
     # region: The default AWS region that this script will connect
     # to for all API calls
@@ -122,13 +127,27 @@ async def main():
     await page.goto(os.environ.get('AWS_LOGIN_URL'))
 
     try:
-        while await page.querySelector('[name*=email], [name*=name]'):
+        while not await is_saml_available(page) and await page.querySelector('[name*=email], [name*=name]'):
             await basic_auth(page)
+            try:
+                await page.waitForNavigation({ 'waitUntil': 'networkidle0', 'timeout': 15000 })
+            except TimeoutError as ex:
+                # When Duo is configured to automatically send push,
+                # saml may be already available at this step or will
+                # soon become available
+                if not await is_saml_available(page):
+                    if await is_duo_available(page):
+                        duo = await get_duo(page)
+                        message = await get_duo_message(duo)
+                        if message:
+                            print(message)
+                    else:
+                        raise ex
 
-        if await page.querySelector('#duo_iframe'):
+        if await is_duo_available(page):
             await duo_auth(page)
-    except:
-        print('Unidentified error, check screenshot')
+    except Exception as ex:
+        print('Unidentified error, check screenshot. Error message: ' + str(ex))
         await page.screenshot({'path': 'error.png'})
         await browser.close()
         exit()


### PR DESCRIPTION
Adds support for Duo accounts configured to automatically send push notification. Also, improves documentation.

Note, the best way to test it is:

```
docker-compose build
docker-compose run --rm aws /bin/bash
shib-auth
```