### PR TITLE
Various small updates

### DIFF
--- a/aws-auth/auth.py
+++ b/aws-auth/auth.py
@@ -80,6 +80,14 @@ async def duo_wait(page, last_message=''):
     except TimeoutError:
         await duo_wait(page, last_message)
 
+def find_file_in_list (list):
+    """find_file_in_list: returns the first file in the list that exists
+        mainly for determining which name to use for chrome
+    """
+    for file in list:
+        if os.path.exists(file):
+            return file
+        
 async def is_duo_available(page):
     return True if await page.querySelector('#duo_iframe') else False
 
@@ -124,9 +132,11 @@ async def main():
         with open(filename, 'w+') as configfile:
             config.write(configfile)
 
+    # determine path to Chrome/Chromium browser
+    browser_path = find_file_in_list( [ '/usr/bin/chromium-browser', '/usr/bin/chromium' ] )
     browser = await launch(
         headless=True,
-        executablePath="/usr/bin/chromium",
+        executablePath=browser_path,
         args=['--no-sandbox', '--disable-gpu']
     )
     page = await browser.newPage()

--- a/aws-auth/auth.py
+++ b/aws-auth/auth.py
@@ -218,7 +218,13 @@ async def main():
 
     # Use the assertion to get an AWS STS token using Assume Role with SAML
     conn = boto.sts.connect_to_region(region)
-    token = conn.assume_role_with_saml(role_arn, principal_arn, samlValue)
+
+    # Try longer lifetime but fall back to the shorter lifetime in case
+    # the role only accepts the shorter lifetime
+    try:
+      token = conn.assume_role_with_saml(role_arn, principal_arn, samlValue, duration_seconds=36000)
+    except:
+      token = conn.assume_role_with_saml(role_arn, principal_arn, samlValue)
 
     if not config.has_section(profile):
         config.add_section(profile)

--- a/aws-auth/auth.py
+++ b/aws-auth/auth.py
@@ -282,12 +282,11 @@ async def main():
     # First, retrieve short-living credentials. 15 is the minimal possible session duration
     token = conn.assume_role_with_saml(role_arn, principal_arn, samlValue, duration_seconds=15*60)
     
-    iam_client = boto3.client('iam', aws_access_key_id=token.credentials.access_key, aws_secret_access_key=token.credentials.secret_key, aws_session_token=token.credentials.session_token)
-
-    current_role = iam_client.get_role(RoleName=role_name)
-    max_session_duration = current_role['Role']['MaxSessionDuration']
-
     try:
+        iam_client = boto3.client('iam', aws_access_key_id=token.credentials.access_key, aws_secret_access_key=token.credentials.secret_key, aws_session_token=token.credentials.session_token)
+        current_role = iam_client.get_role(RoleName=role_name)
+        max_session_duration = current_role['Role']['MaxSessionDuration']
+
         print('')
         print('Configuring session to last {0} seconds'.format(max_session_duration))
         token = conn.assume_role_with_saml(role_arn, principal_arn, samlValue, duration_seconds=max_session_duration)

--- a/bin/shib-auth
+++ b/bin/shib-auth
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python3 /aws-auth/auth.py
+python3 /aws-auth/auth.py "$@"


### PR DESCRIPTION
This pull request collects a few different small changes:
1) The auth,py script will try a few different browser names to support different Linux environments.
2) shib-auth's single parameter is the AWS cli profile name to authentication (default is default)
3) It will try to assume role for 10 hour credentials falling back to 1 hour.  InfoSec will be able to control which roles can get the longer lifespan by role's CloudFormation settings.