### PR TITLE
Updated alpine to latest 3.13 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex; \
       groff \
       py-pip \
       python3 \
+      py3-bcrypt py3-cryptography py3-pynacl \
       chromium \
       udev \
       ttf-freefont \
@@ -29,6 +30,8 @@ RUN set -ex; \
 RUN pip3 install --upgrade \
       pip \
       aws-shell \
+      awscli \
+      awsebcli \
       boto==2.49.0 \
       pyppeteer==0.2.5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11.2
+FROM alpine:3.13
 
 # Configure less
 ENV PAGER="less -r"
@@ -29,12 +29,8 @@ RUN set -ex; \
 RUN pip3 install --upgrade \
       pip \
       aws-shell \
-      awsebcli \
       boto==2.49.0 \
-      pyppeteer==0.0.25
-
-# Hand-patch the issue with Network Timeouts, see https://github.com/miyakogi/pyppeteer/pull/160
-RUN sed -i 's/self._url, max_size=None, loop=self._loop)/self._url, max_size=None, loop=self._loop, ping_interval=None, ping_timeout=None)/' /usr/lib/python3.8/site-packages/pyppeteer/connection.py
+      pyppeteer==0.2.5
 
 # Install ecs-cli
 RUN curl -o /usr/local/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest && chmod u+x /usr/local/bin/ecs-cli

--- a/README.md
+++ b/README.md
@@ -134,3 +134,16 @@ Then, execute bash session in the container:
 ```bash
 docker-compose exec aws bash
 ```
+
+## Multi-architecture builds
+
+This assumes that you have enabled multi-archecture builds with buildx.  If not then
+see various sources on how to set that up such as:
+
+https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408
+
+Once we have a buildx builder we can build and push images to DockerHub by:
+
+```bash
+$ docker buildx build -t "org/aws-tools:latest" --platform linux/amd64,linux/arm64 --push .
+```

--- a/aws-auth/auth.py
+++ b/aws-auth/auth.py
@@ -55,7 +55,7 @@ class MyHTMLParser(HTMLParser):
                 accountname[match.group(2)] = match.group(1)
             # Set flag so that we no longer care about content (until we get another div match)
             MyHTMLParser.processing_account_div = False
- 
+
 
 async def basic_auth(page):
     error = await page.querySelector('.error-box')
@@ -237,11 +237,15 @@ async def main():
         i = 0
         print("Please choose the role you would like to assume:")
         for awsrole in awsroles:
-            print('[', i, ']: ', awsrole.split(',')[0],end='')
-            match = re.search("::(\d+):role",awsrole)
-            if (match):
-                print("     (" + accountname[match.group(1)] + ")",end='')
-            print()
+            role_str = awsrole.split(',', 2)[0]
+            role_expanded = role_str.split(':', 5)
+            role_account = role_expanded[4]
+            role_name = role_expanded[5]
+            if '/' in role_name:
+              label = role_name.split('/', 2)[1]
+            else:
+              label = role_str
+            print('[%d]: %s    %s' % (i, accountname.get(role_account, role_account), label) )
             i += 1
         print("Selection: ", end="")
         selectedroleindex = input()

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-echo "If you need to authenticate for a regular AWS account: aws configure"
-echo ""
-echo "If you need to authenticate using Shibboleth: shib-auth"
+if [ "$1" = shib-auth ]; then
+  echo "Shibboleth authentication for profile: $2"
+  echo ""
+else
+  echo "If you need to authenticate for a regular AWS account: aws configure"
+  echo ""
+  echo "If you need to authenticate using Shibboleth: shib-auth"
+fi
 
 if [ ! -f /root/.aws/credentials ]; then
     mkdir -p /root/.aws

--- a/bin/shib-auth
+++ b/bin/shib-auth
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python3 /aws-auth/auth.py
+exec python3 /aws-auth/auth.py "$@"


### PR DESCRIPTION
This builds properly with Alpine 3.13 and has the latest version of awscli v1.

It has been tested both with shib-auth and the aws cli on x86_64.  It has not yet been tested with aarch64 (such as the new Apple M1 systems).

Once this has been integrated I want to make a few changes to shib-auth.