### PR TITLE
Feat misc updates

### DIFF
--- a/aws-auth/auth.py
+++ b/aws-auth/auth.py
@@ -55,7 +55,7 @@ class MyHTMLParser(HTMLParser):
                 accountname[match.group(2)] = match.group(1)
             # Set flag so that we no longer care about content (until we get another div match)
             MyHTMLParser.processing_account_div = False
- 
+
 
 async def basic_auth(page):
     error = await page.querySelector('.error-box')
@@ -237,11 +237,15 @@ async def main():
         i = 0
         print("Please choose the role you would like to assume:")
         for awsrole in awsroles:
-            print('[', i, ']: ', awsrole.split(',')[0],end='')
-            match = re.search("::(\d+):role",awsrole)
-            if (match):
-                print("     (" + accountname[match.group(1)] + ")",end='')
-            print()
+            role_str = awsrole.split(',', 2)[0]
+            role_expanded = role_str.split(':', 5)
+            role_account = role_expanded[4]
+            role_name = role_expanded[5]
+            if '/' in role_name:
+              label = role_name.split('/', 2)[1]
+            else:
+              label = role_str
+            print('[%d]: %s    %s' % (i, accountname.get(role_account, role_account), label) )
             i += 1
         print("Selection: ", end="")
         selectedroleindex = input()

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-echo "If you need to authenticate for a regular AWS account: aws configure"
-echo ""
-echo "If you need to authenticate using Shibboleth: shib-auth"
+if [ "$1" = shib-auth ]; then
+  echo "Shibboleth authentication for profile: $2"
+  echo ""
+else
+  echo "If you need to authenticate for a regular AWS account: aws configure"
+  echo ""
+  echo "If you need to authenticate using Shibboleth: shib-auth"
+fi
 
 if [ ! -f /root/.aws/credentials ]; then
     mkdir -p /root/.aws

--- a/bin/shib-auth
+++ b/bin/shib-auth
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python3 /aws-auth/auth.py
+exec python3 /aws-auth/auth.py "$@"


### PR DESCRIPTION
This collects a few small updates based on how we are using was-tools now:
1) Do not display the "If you need to authenticate" help text if directly executing Shib-auth
2) Can now specify which profile Shib-auth authenticates which allows for multiple active sessions at the same time.
3) Cleaned up the output to make it easier to connect the account name to the number to select.

