### PR TITLE
Support for longer sessions and sorted output

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": []
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN pip3 install --upgrade \
       pip \
       aws-shell \
       awscli \
-      awsebcli \
       boto==2.49.0 \
       pyppeteer==0.2.5
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ been only tested for the `push` method (both manual and automated).
 
 You can modify these environment variables to fine-tune for your own case:
 
+You can also put the credentials into a non-default profile by adding the profile name to
+the end of the command line:
+
+```bash
+docker run --rm -it --volume "$HOME/.aws:/root/.aws" bostonuniversity/aws-tools shib-auth security
+```
+
+or the following if you made the above alias:
+
+```bash
+awslogin security
+```
+
 Variable name        | Default value
 ---------------------|------------------------------
 AWS_REGION           | `us-east-1`
@@ -101,7 +114,6 @@ docker run --rm -it --volume ${PWD}:/code --volume C:\Some\Temporary\Directory:/
 
 - `aws-cli`
 - `aws-shell`
-- `awsebcli`
 - `ecs-cli`
 
 ### Other

--- a/aws-auth/auth.py
+++ b/aws-auth/auth.py
@@ -133,7 +133,7 @@ async def is_saml_available(page):
 async def main():
     # region: The default AWS region that this script will connect
     # to for all API calls
-    region = os.environ.get('AWS_REGION')
+    region = os.environ.get('AWS_REGION', "us-east-1")
 
     # output format: The AWS CLI output format that will be configured in the
     # saml profile (affects subsequent CLI calls)
@@ -173,7 +173,7 @@ async def main():
         args=['--no-sandbox', '--disable-gpu']
     )
     page = await browser.newPage()
-    await page.goto(os.environ.get('AWS_LOGIN_URL'))
+    await page.goto(os.environ.get('AWS_LOGIN_URL', 'https://www.bu.edu/awslogin'))
 
     try:
         while not await is_saml_available(page) and await page.querySelector('[name*=email], [name*=name]'):


### PR DESCRIPTION
The primary reason for this update is to get rid of the 1hr command line session duration.  This code was the only thing keeping the 1 hour duration as the IAM roles already had a longer max session duration and earlier this summer Shibboleth started requesting a longer session duration.  

At the same time I've sorted the roles - some of us have over 20 so the unsorted list is not useful.

I also did a few other minor tweaks either to simplify development with VScode's Python debugger or to clean up output.  